### PR TITLE
Allow specifying custom error messages when failing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,20 +19,27 @@ locals {
 }
 
 resource "errorcheck_is_valid" "shouldMatch" {
-  name = "shouldMatch"
-  test = local.compare == local.testSuccess
+  name = "check_something"
+  test = {
+    assert = local.compare == local.testSuccess
+    error_message = "Your assertion is not valid"
+  }
 }
 
 resource "errorcheck_is_valid" "Not_valid_if_not_match" {
-  name = "Not_valid_if_not_match"
-  test = local.compare == local.testFail
+  name = "Should not match"
+  test = {
+    assert = local.compare == local.testFail
+    error_message = "Your assertion is not valid"
+  }
 }
+
 ```
 output:
 ```bash
 terraform validate .
 
-Error: Not Valid
+Error: Your assertion is not valid
 
   on main.tf line 11, in resource "errorcheck_is_valid" "Not_valid_if_not_match":
   11: resource "errorcheck_is_valid" "Not_valid_if_not_match" {

--- a/main.tf
+++ b/main.tf
@@ -5,9 +5,17 @@ locals {
 }
 
 resource "errorcheck_is_valid" "shouldMatch" {
-  test = local.compare == local.testSuccess
+  name = "check_something"
+  test = {
+    assert = local.compare == local.testSuccess
+    error_message = "Your assertion is not valid"
+  }
 }
 
 resource "errorcheck_is_valid" "Not_valid_if_not_match" {
-  test = local.compare == local.testFail
+  name = "Should not match"
+  test = {
+    assert = local.compare == local.testFail
+    error_message = "Your assertion is not valid"
+  }
 }


### PR DESCRIPTION
Modify 'test' attribute to become a map that stores an assertion and an optional custom 'error_message'

Resource example:
```hcl
resource "errorcheck_is_valid" "check_something" {
  name = "Check that 1 == 2"
  test = {
    assert = 1 == 2
    error_message = "Assertion failed"
  }
}

```

Output:
```shell
$ terraform plan
Error: Assertion failed

  on main.tf line 23, in resource "errorcheck_is_valid" "check_something":
  23: resource "errorcheck_is_valid" "check_something" {
```